### PR TITLE
One more rename edges -> neighbors in dependeny graph command

### DIFF
--- a/lib/pandan/command/dependency_graph.rb
+++ b/lib/pandan/command/dependency_graph.rb
@@ -68,7 +68,7 @@ module Pandan
 
       graph.nodes.each do |_, node|
         target_node = graphviz.add_node(node.name)
-        node.edges.each do |dependency|
+        node.neighbors.each do |dependency|
           dep_node = graphviz.add_node(dependency.name)
           graphviz.add_edge(target_node, dep_node)
         end


### PR DESCRIPTION
We missed one occurrence of `edges` when renaming to `neighbors`.