### PR TITLE
Fix filtering in query and dependency-graph commands

### DIFF
--- a/lib/pandan/command/dependency_graph.rb
+++ b/lib/pandan/command/dependency_graph.rb
@@ -25,6 +25,7 @@ module Pandan
       @save_gv = argv.flag?('graphviz')
       @save_png = argv.flag?('image')
       @filter = argv.option('filter')
+      @filter ||= '.*' # Match everything
       super
     end
 

--- a/lib/pandan/command/dependency_graph.rb
+++ b/lib/pandan/command/dependency_graph.rb
@@ -65,8 +65,10 @@ module Pandan
       graphviz = GraphViz.new(type: :digraph)
 
       graph.nodes.each do |_, node|
+        next unless node.name =~ /#{@filter}/
         target_node = graphviz.add_node(node.name)
         node.neighbors.each do |dependency|
+          next unless dependency.name =~ /#{@filter}/
           dep_node = graphviz.add_node(dependency.name)
           graphviz.add_edge(target_node, dep_node)
         end

--- a/lib/pandan/command/query.rb
+++ b/lib/pandan/command/query.rb
@@ -46,11 +46,9 @@ module Pandan
       graph = Graph.new(@reverse)
       graph.add_target_info(targets)
       deps = graph.resolve_dependencies(@target).map(&:name)
-      unless @filter.nil?
-        deps.select! do |dep|
+      deps.select! do |dep|
           dep =~ /#{@filter}/
         end
-      end
 
       if @comma_separated
         puts deps.join ','

--- a/lib/pandan/command/query.rb
+++ b/lib/pandan/command/query.rb
@@ -29,6 +29,7 @@ module Pandan
       @reverse = argv.flag?('reverse')
       @comma_separated = argv.flag?('comma-separated')
       @filter = argv.option('filter')
+      @filter ||= '.*' # Match everything
       super
     end
 

--- a/lib/pandan/command/query.rb
+++ b/lib/pandan/command/query.rb
@@ -47,7 +47,7 @@ module Pandan
       deps = graph.resolve_dependencies(@target).map(&:name)
       unless @filter.nil?
         deps.select! do |dep|
-          dep.name.include? @filter
+          dep =~ /#{@filter}/
         end
       end
 


### PR DESCRIPTION
Small filtering fixes:
- Replace one leftover `.include?` from the switch from exclude to a regex filter with `=~`
- Filter the node names when generating a dependency graph
- Add default `'.*'` filters to the commands to make the code a bit simpler