### PR TITLE
Add implicit dependencies analysis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in pandan.gemspec
 gemspec
+gem 'xcodeproj', git: 'git://github.com/ruenzuo/xcodeproj', branch: 'resolve_build_setting'
 
 group :development do
   gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in pandan.gemspec
 gemspec
-gem 'xcodeproj', git: 'git://github.com/ruenzuo/xcodeproj', branch: 'resolve_build_setting'
+gem 'xcodeproj', git: 'git://github.com/cocoapods/xcodeproj'
 
 group :development do
   gem 'rubocop'

--- a/lib/pandan/command/query.rb
+++ b/lib/pandan/command/query.rb
@@ -13,6 +13,7 @@ module Pandan
       [
         ['--xcworkspace=path/to/workspace', 'If not set, Pandan will try to find a workspace'],
         ['--reverse', 'If set, pandan will output the targets that depend on the argument'],
+        ['--implicit-dependencies', 'If set, pandan will look up for -l and -framework linker flags in all build configurations'],
         ['--comma-separated', 'If set, Pandan outputs a comma-separated list instead of multiple lines'],
         ['--filter=expression', 'If set, pandan will select all targets whose name match the regular expression']
       ].concat(super)
@@ -27,6 +28,7 @@ module Pandan
       @xcworkspace = argv.option('xcworkspace')
       @xcworkspace ||= XCWorkspace.find_workspace
       @reverse = argv.flag?('reverse')
+      @implicit_deps = argv.flag?('implicit-dependencies')
       @comma_separated = argv.flag?('comma-separated')
       @filter = argv.option('filter')
       @filter ||= '.*' # Match everything
@@ -42,9 +44,13 @@ module Pandan
 
     def run
       parser = Parser.new(@xcworkspace, @filter)
-      targets = parser.all_targets
       graph = Graph.new(@reverse)
+      targets = parser.all_targets
       graph.add_target_info(targets)
+      if @implicit_deps
+        ld_flags_info = parser.other_linker_flags
+        graph.add_other_ld_flags_info(ld_flags_info)
+      end
       deps = graph.resolve_dependencies(@target).map(&:name)
       deps.select! do |dep|
         dep =~ /#{@filter}/

--- a/lib/pandan/command/query.rb
+++ b/lib/pandan/command/query.rb
@@ -13,7 +13,7 @@ module Pandan
       [
         ['--xcworkspace=path/to/workspace', 'If not set, Pandan will try to find a workspace'],
         ['--reverse', 'If set, pandan will output the targets that depend on the argument'],
-        ['--implicit-dependencies', 'If set, pandan will look up for -l and -framework linker flags in all build configurations'],
+        ['--implicit-dependencies', 'If set, pandan will look up for linker flags in all build configurations'],
         ['--comma-separated', 'If set, Pandan outputs a comma-separated list instead of multiple lines'],
         ['--filter=expression', 'If set, pandan will select all targets whose name match the regular expression']
       ].concat(super)

--- a/lib/pandan/graph.rb
+++ b/lib/pandan/graph.rb
@@ -39,11 +39,11 @@ module Pandan
       ld_flags_info.each do |target, ld_flags_per_config|
         node = node_for_target_display_name(target.display_name)
         ld_flags_per_config.each do |_config, ld_flags|
-          ld_flags.match(/-l"(.*?)"/).captures.each do |library|
+          ld_flags.join(' ').match(/-l"(.*?)"/).captures.each do |library|
             library_node = node_for_target_display_name(library)
             add_neighbor(node, library_node)
           end
-          ld_flags.match(/-framework "(.*?)"/).captures.each do |framework|
+          ld_flags.join(' ').match(/-framework "(.*?)"/).captures.each do |framework|
             framework_node = node_for_target_display_name(framework)
             add_neighbor(node, framework_node)
           end

--- a/lib/pandan/graph.rb
+++ b/lib/pandan/graph.rb
@@ -35,6 +35,22 @@ module Pandan
       end
     end
 
+    def add_other_ld_flags_info(ld_flags_info)
+      ld_flags_info.each do |target, ld_flags_per_config|
+        node = node_for_target_display_name(target.display_name)
+        ld_flags_per_config.each do |config, ld_flags|
+          ld_flags.match(/-l"(.*?)"/).captures.each do |library|
+            library_node = node_for_target_display_name(library)
+            add_neighbor(node, library_node)
+          end
+          ld_flags.match(/-framework "(.*?)"/).captures.each do |framework|
+            framework_node = node_for_target_display_name(framework)
+            add_neighbor(node, framework_node)
+          end
+        end
+      end
+    end
+
     def resolve_dependencies(target)
       resolved = []
       target_node = nodes[target]

--- a/lib/pandan/graph.rb
+++ b/lib/pandan/graph.rb
@@ -27,22 +27,10 @@ module Pandan
     def add_target_info(targets)
       targets.each do |target|
         linked_libraries = find_linked_libraries(target)
-        node = nodes[target.display_name]
-        if node.nil?
-          node = Node.new(target.display_name)
-          nodes[target.display_name] = node
-        end
+        node = node_for_target_display_name(target.display_name)
         linked_libraries.each do |library_name|
-          library_node = nodes[library_name]
-          if library_node.nil?
-            library_node = Node.new(library_name)
-            nodes[library_name] = library_node
-          end
-          if reverse
-            library_node.add_neighbor(node)
-          else
-            node.add_neighbor(library_node)
-          end
+          library_node = node_for_target_display_name(library_name)
+          add_neighbor(node, library_node)
         end
       end
     end
@@ -57,6 +45,23 @@ module Pandan
     end
 
     private
+
+    def node_for_target_display_name(display_name)
+      node = nodes[display_name]
+      if node.nil?
+        node = Node.new(display_name)
+        nodes[display_name] = node
+      end
+      node
+    end
+
+    def add_neighbor(source, destination)
+      if reverse
+        destination.add_neighbor(source)
+      else
+        source.add_neighbor(destination)
+      end
+    end
 
     def find_linked_libraries(target)
       frameworks_build_phase = target.build_phases.find { |build_phase| build_phase.isa.eql? 'PBXFrameworksBuildPhase' }

--- a/lib/pandan/graph.rb
+++ b/lib/pandan/graph.rb
@@ -38,7 +38,7 @@ module Pandan
     def add_other_ld_flags_info(ld_flags_info)
       ld_flags_info.each do |target, ld_flags_per_config|
         node = node_for_target_display_name(target.display_name)
-        ld_flags_per_config.each do |config, ld_flags|
+        ld_flags_per_config.each do |_config, ld_flags|
           ld_flags.match(/-l"(.*?)"/).captures.each do |library|
             library_node = node_for_target_display_name(library)
             add_neighbor(node, library_node)

--- a/lib/pandan/parser.rb
+++ b/lib/pandan/parser.rb
@@ -12,11 +12,26 @@ module Pandan
     end
 
     def all_targets
+      @projects ||= projects
+      projects.flat_map(&:targets).select { |target| target.name =~ /#{regex}/ }
+    end
+
+    def other_linker_flags
+      @projects ||= projects
+      ld_flags_info = {}
+      projects.flat_map(&:targets).each do |target|
+        ld_flags_info[target] = target.resolved_build_setting('OTHER_LDFLAGS', true)
+      end
+      ld_flags_info
+    end
+
+    private
+
+    def projects
       all_project_paths = workspace.file_references.map(&:path)
-      projects = all_project_paths.map do |project_path|
+      all_project_paths.map do |project_path|
         Xcodeproj::Project.open(File.expand_path(project_path, @workspace_dir))
       end
-      projects.flat_map(&:targets).select { |target| target.name =~ /#{regex}/ }
     end
   end
 end

--- a/spec/fixtures/xcworkspace_using_only_build_settings/Sample.xcodeproj/project.pbxproj
+++ b/spec/fixtures/xcworkspace_using_only_build_settings/Sample.xcodeproj/project.pbxproj
@@ -1,0 +1,330 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3F44C73E1E90506000D66F67 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F44C73D1E90506000D66F67 /* main.m */; };
+		3F44C7411E90506000D66F67 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F44C7401E90506000D66F67 /* AppDelegate.m */; };
+		3F44C7441E90506000D66F67 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F44C7431E90506000D66F67 /* ViewController.m */; };
+		3F44C7471E90506000D66F67 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F44C7451E90506000D66F67 /* Main.storyboard */; };
+		3F44C7491E90506000D66F67 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F44C7481E90506000D66F67 /* Assets.xcassets */; };
+		3F44C74C1E90506000D66F67 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F44C74A1E90506000D66F67 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		3F44C7391E90506000D66F67 /* Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F44C73D1E90506000D66F67 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		3F44C73F1E90506000D66F67 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		3F44C7401E90506000D66F67 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		3F44C7421E90506000D66F67 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		3F44C7431E90506000D66F67 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		3F44C7461E90506000D66F67 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		3F44C7481E90506000D66F67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3F44C74B1E90506000D66F67 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3F44C74D1E90506000D66F67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3F44C7541E90514F00D66F67 /* Frameworks.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Frameworks.xcconfig; sourceTree = "<group>"; };
+		3F44C76A1E9056BD00D66F67 /* Libraries.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Libraries.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3F44C7361E90506000D66F67 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3F44C7301E90506000D66F67 = {
+			isa = PBXGroup;
+			children = (
+				3F44C73B1E90506000D66F67 /* Sample */,
+				3F44C73A1E90506000D66F67 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3F44C73A1E90506000D66F67 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3F44C7391E90506000D66F67 /* Sample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3F44C73B1E90506000D66F67 /* Sample */ = {
+			isa = PBXGroup;
+			children = (
+				3F44C73F1E90506000D66F67 /* AppDelegate.h */,
+				3F44C7401E90506000D66F67 /* AppDelegate.m */,
+				3F44C7421E90506000D66F67 /* ViewController.h */,
+				3F44C7431E90506000D66F67 /* ViewController.m */,
+				3F44C7451E90506000D66F67 /* Main.storyboard */,
+				3F44C7481E90506000D66F67 /* Assets.xcassets */,
+				3F44C74A1E90506000D66F67 /* LaunchScreen.storyboard */,
+				3F44C74D1E90506000D66F67 /* Info.plist */,
+				3F44C73C1E90506000D66F67 /* Supporting Files */,
+				3F44C7541E90514F00D66F67 /* Frameworks.xcconfig */,
+				3F44C76A1E9056BD00D66F67 /* Libraries.xcconfig */,
+			);
+			path = Sample;
+			sourceTree = "<group>";
+		};
+		3F44C73C1E90506000D66F67 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				3F44C73D1E90506000D66F67 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3F44C7381E90506000D66F67 /* Sample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3F44C7501E90506000D66F67 /* Build configuration list for PBXNativeTarget "Sample" */;
+			buildPhases = (
+				3F44C7351E90506000D66F67 /* Sources */,
+				3F44C7361E90506000D66F67 /* Frameworks */,
+				3F44C7371E90506000D66F67 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Sample;
+			productName = Sample;
+			productReference = 3F44C7391E90506000D66F67 /* Sample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3F44C7311E90506000D66F67 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0830;
+				ORGANIZATIONNAME = "Renzo Crisóstomo";
+				TargetAttributes = {
+					3F44C7381E90506000D66F67 = {
+						CreatedOnToolsVersion = 8.3;
+						DevelopmentTeam = 7A5BJMR95M;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 3F44C7341E90506000D66F67 /* Build configuration list for PBXProject "Sample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 3F44C7301E90506000D66F67;
+			productRefGroup = 3F44C73A1E90506000D66F67 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3F44C7381E90506000D66F67 /* Sample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3F44C7371E90506000D66F67 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3F44C74C1E90506000D66F67 /* LaunchScreen.storyboard in Resources */,
+				3F44C7491E90506000D66F67 /* Assets.xcassets in Resources */,
+				3F44C7471E90506000D66F67 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3F44C7351E90506000D66F67 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3F44C7441E90506000D66F67 /* ViewController.m in Sources */,
+				3F44C7411E90506000D66F67 /* AppDelegate.m in Sources */,
+				3F44C73E1E90506000D66F67 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		3F44C7451E90506000D66F67 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3F44C7461E90506000D66F67 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		3F44C74A1E90506000D66F67 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3F44C74B1E90506000D66F67 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		3F44C74E1E90506000D66F67 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3F44C76A1E9056BD00D66F67 /* Libraries.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3F44C74F1E90506000D66F67 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3F44C76A1E9056BD00D66F67 /* Libraries.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3F44C7511E90506000D66F67 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3F44C7541E90514F00D66F67 /* Frameworks.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 7A5BJMR95M;
+				INFOPLIST_FILE = Sample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = de.ruenzuo.Sample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		3F44C7521E90506000D66F67 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3F44C7541E90514F00D66F67 /* Frameworks.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 7A5BJMR95M;
+				INFOPLIST_FILE = Sample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = de.ruenzuo.Sample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3F44C7341E90506000D66F67 /* Build configuration list for PBXProject "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3F44C74E1E90506000D66F67 /* Debug */,
+				3F44C74F1E90506000D66F67 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3F44C7501E90506000D66F67 /* Build configuration list for PBXNativeTarget "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3F44C7511E90506000D66F67 /* Debug */,
+				3F44C7521E90506000D66F67 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3F44C7311E90506000D66F67 /* Project object */;
+}

--- a/spec/fixtures/xcworkspace_using_only_build_settings/Sample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/spec/fixtures/xcworkspace_using_only_build_settings/Sample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Sample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/spec/fixtures/xcworkspace_using_only_build_settings/Sample.xcworkspace/contents.xcworkspacedata
+++ b/spec/fixtures/xcworkspace_using_only_build_settings/Sample.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Sample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/spec/fixtures/xcworkspace_using_only_build_settings/Sample/Frameworks.xcconfig
+++ b/spec/fixtures/xcworkspace_using_only_build_settings/Sample/Frameworks.xcconfig
@@ -1,0 +1,10 @@
+//
+//  Config.xcconfig
+//  Sample
+//
+//  Created by Renzo Crisóstomo on 01.04.17.
+//  Copyright © 2017 Renzo Crisóstomo. All rights reserved.
+//
+
+OTHER_LDFLAGS = $(inherited) -framework GoogleMobileAds
+FRAMEWORK_SEARCH_PATHS = $(SOURCE_ROOT)/Frameworks

--- a/spec/fixtures/xcworkspace_using_only_build_settings/Sample/Libraries.xcconfig
+++ b/spec/fixtures/xcworkspace_using_only_build_settings/Sample/Libraries.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Libraries.xcconfig
+//  Sample
+//
+//  Created by Renzo Crisóstomo on 01.04.17.
+//  Copyright © 2017 Renzo Crisóstomo. All rights reserved.
+//
+
+OTHER_LDFLAGS = -l Baka
+HEADER_SEARCH_PATHS = $(SOURCE_ROOT)/Libraries/**
+LIBRARY_SEARCH_PATHS = $(SOURCE_ROOT)/Libraries/**

--- a/spec/pandan_spec.rb
+++ b/spec/pandan_spec.rb
@@ -77,4 +77,18 @@ RSpec.describe Pandan do
       expect(dependencies.map(&:name)).to match_array expected_dependencies
     end
   end
+
+  it 'graph works with dependencies defined using build settings' do
+    use_fixture('xcworkspace_using_only_build_settings') do
+      parser = Pandan::Parser.new('Sample.xcworkspace', nil)
+      targets = parser.all_targets
+      ld_flags_info = parser.other_linker_flags
+      graph = Pandan::Graph.new(false)
+      graph.add_target_info(targets)
+      graph.add_other_ld_flags_info(ld_flags_info)
+      dependencies = graph.resolve_dependencies('Sample')
+      expected_dependencies = %w(Baka GoogleMobileAds)
+      expect(dependencies.map(&:name)).to match_array expected_dependencies
+    end
+  end
 end

--- a/spec/pandan_spec.rb
+++ b/spec/pandan_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Pandan do
       graph = Pandan::Graph.new(false)
       graph.add_target_info(targets)
       dependencies = graph.resolve_dependencies('SampleFrameworkB')
-      expected_dependencies = %w(SampleFrameworkC SampleFrameworkD SampleFrameworkE)
+      expected_dependencies = %w[SampleFrameworkC SampleFrameworkD SampleFrameworkE]
       expect(dependencies.map(&:name)).to match_array expected_dependencies
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe Pandan do
       graph = Pandan::Graph.new(false)
       graph.add_target_info(targets)
       dependencies = graph.resolve_dependencies('SampleFrameworkB')
-      expected_dependencies = %w(SampleFrameworkC SampleFrameworkD SampleFrameworkE)
+      expected_dependencies = %w[SampleFrameworkC SampleFrameworkD SampleFrameworkE]
       expect(dependencies.map(&:name)).to match_array expected_dependencies
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe Pandan do
       graph = Pandan::Graph.new(true)
       graph.add_target_info(targets)
       dependencies = graph.resolve_dependencies('SampleFrameworkB')
-      expected_dependencies = %w(SampleApp SampleFrameworkBTests)
+      expected_dependencies = %w[SampleApp SampleFrameworkBTests]
       expect(dependencies.map(&:name)).to match_array expected_dependencies
     end
   end
@@ -72,8 +72,8 @@ RSpec.describe Pandan do
       graph = Pandan::Graph.new(false)
       graph.add_target_info(targets)
       dependencies = graph.resolve_dependencies('XNGAPIClient')
-      expected_dependencies = %w(AFNetworking CoreGraphics Foundation MobileCoreServices
-                                 SAMKeychain Security SystemConfiguration UIKit XNGOAuth1Client)
+      expected_dependencies = %w[AFNetworking CoreGraphics Foundation MobileCoreServices
+                                 SAMKeychain Security SystemConfiguration UIKit XNGOAuth1Client]
       expect(dependencies.map(&:name)).to match_array expected_dependencies
     end
   end
@@ -87,7 +87,7 @@ RSpec.describe Pandan do
       graph.add_target_info(targets)
       graph.add_other_ld_flags_info(ld_flags_info)
       dependencies = graph.resolve_dependencies('Sample')
-      expected_dependencies = %w(Baka GoogleMobileAds)
+      expected_dependencies = %w[Baka GoogleMobileAds]
       expect(dependencies.map(&:name)).to match_array expected_dependencies
     end
   end


### PR DESCRIPTION
This PR adds support for implicit dependencies analysis. For instance, given a project that has its "Link Binary With Libraries" build phase empty, but uses build settings (namely, OTHER_LDFLAGS) to set up it's dependencies, pandan will parse this settings (even from xcconfig files) and create the proper nodes for the analysis graph.

Check [xcode_project_use_only_xcconfig_to_pass_linker_flags](https://github.com/Ruenzuo/xcode_project_use_only_xcconfig_to_pass_linker_flags) for an example of this case. 

This PR depends on https://github.com/CocoaPods/Xcodeproj/pull/476
This PR is related to https://github.com/xing/pandan/issues/7.