### PR TITLE
Handle finding linked libraries on targets without framework build phase

### DIFF
--- a/lib/pandan/graph.rb
+++ b/lib/pandan/graph.rb
@@ -83,6 +83,9 @@ module Pandan
 
     def find_linked_libraries(target)
       frameworks_build_phase = target.build_phases.find { |build_phase| build_phase.isa.eql? 'PBXFrameworksBuildPhase' }
+
+      return [] unless frameworks_build_phase
+
       frameworks_build_phase.files.map { |file| file.display_name.gsub '.framework', '' }
     end
 


### PR DESCRIPTION
CocoaPods can generate a target that doesn’t contain a framework build phase. This causes the `find_linked_libraries` method to fail since `frameworks_build_phase` ends up being `nil`. Avoid this issue by returning `[]` when no framework build phase is found.

|Example Failing Target|
|---|
|<img width="1190" alt="Screen Shot 2020-01-16 at 3 58 13 PM" src="https://user-images.githubusercontent.com/5728070/72573419-73e87080-387a-11ea-9dc6-400e849e10c6.png">|

Example failure traceback:
```
Traceback (most recent call last):
	9: from /Users/mattrobinson/.rbenv/versions/2.6.3/bin/pandan:23:in `<main>'
	8: from /Users/mattrobinson/.rbenv/versions/2.6.3/bin/pandan:23:in `load'
	7: from /Users/mattrobinson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pandan-0.0.3/bin/pandan:7:in `<top (required)>'
	6: from /Users/mattrobinson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pandan-0.0.3/lib/pandan.rb:9:in `run'
	5: from /Users/mattrobinson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
	4: from /Users/mattrobinson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pandan-0.0.3/lib/pandan/command/query.rb:51:in `run'
	3: from /Users/mattrobinson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pandan-0.0.3/lib/pandan/graph.rb:30:in `add_target_info'
	2: from /Users/mattrobinson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pandan-0.0.3/lib/pandan/graph.rb:30:in `each'
	1: from /Users/mattrobinson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pandan-0.0.3/lib/pandan/graph.rb:31:in `block in add_target_info'
/Users/mattrobinson/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/pandan-0.0.3/lib/pandan/graph.rb:86:in `find_linked_libraries': undefined method `files' for nil:NilClass (NoMethodError)
```